### PR TITLE
Refactor implementation of SourceFile.lines_with_endings

### DIFF
--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -31,7 +31,8 @@ defmodule ElixirLS.LanguageServer.Mixfile do
       {:forms, "~> 0.0.1"},
       {:erl2ex, github: "dazuma/erl2ex"},
       {:dialyxir, "~> 1.0.0", runtime: false},
-      {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"}
+      {:jason_vendored, github: "elixir-lsp/jason", branch: "vendored"},
+      {:stream_data, "~> 0.5.0", only: :test}
     ]
   end
 

--- a/apps/language_server/test/source_file_test.exs
+++ b/apps/language_server/test/source_file_test.exs
@@ -1,5 +1,6 @@
 defmodule ElixirLS.LanguageServer.SourceFileTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias ElixirLS.LanguageServer.SourceFile
 
@@ -578,5 +579,69 @@ defmodule ElixirLS.LanguageServer.SourceFileTest do
     assert %{"end" => %{"character" => 2, "line" => 1}} = SourceFile.full_range(new("a\naa"))
     assert %{"end" => %{"character" => 2, "line" => 1}} = SourceFile.full_range(new("a\r\naa"))
     assert %{"end" => %{"character" => 8, "line" => 1}} = SourceFile.full_range(new("a\naa🏳️‍🌈"))
+  end
+
+  describe "lines_with_endings/1" do
+    test "with an empty string" do
+      assert SourceFile.lines_with_endings("") == [{"", nil}]
+    end
+
+    test "without any endings" do
+      assert SourceFile.lines_with_endings("basic") == [{"basic", nil}]
+    end
+
+    test "with a LF" do
+      assert SourceFile.lines_with_endings("text\n") == [{"text", "\n"}, {"", nil}]
+    end
+
+    test "with a CR LF" do
+      assert SourceFile.lines_with_endings("text\r\n") == [{"text", "\r\n"}, {"", nil}]
+    end
+
+    test "with multiple LF lines" do
+      assert SourceFile.lines_with_endings("line1\nline2\nline3") == [
+               {"line1", "\n"},
+               {"line2", "\n"},
+               {"line3", nil}
+             ]
+    end
+
+    test "with multiple CR LF line endings" do
+      text = "A\r\nB\r\n\r\nC"
+
+      assert SourceFile.lines_with_endings(text) == [
+               {"A", "\r\n"},
+               {"B", "\r\n"},
+               {"", "\r\n"},
+               {"C", nil}
+             ]
+    end
+
+    test "with an emoji" do
+      text = "👨‍👩‍👦 test"
+      assert SourceFile.lines_with_endings(text) == [{"👨‍👩‍👦 test", nil}]
+    end
+
+    test "example multi-byte string" do
+      text = "𐂀"
+      assert String.valid?(text)
+      [{line, ending}] = SourceFile.lines_with_endings(text)
+      assert String.valid?(line)
+      assert ending in ["\r\n", "\n", "\r", nil]
+    end
+
+    property "always creates valid binaries" do
+      check all elements <- list_of(one_of([
+            string(:printable),
+            one_of([constant("\r\n"), constant("\n"), constant("\r")])
+          ])) do
+        text = List.to_string(elements)
+        lines_w_endings = SourceFile.lines_with_endings(text)
+        Enum.each(lines_w_endings, fn {line, ending} ->
+          assert String.valid?(line)
+          assert ending in ["\r\n", "\n", "\r", nil]
+        end)
+      end
+    end
   end
 end

--- a/apps/language_server/test/test_helper.exs
+++ b/apps/language_server/test/test_helper.exs
@@ -1,2 +1,3 @@
 Application.put_env(:language_server, :test_mode, true)
+Application.ensure_started(:stream_data)
 ExUnit.start(exclude: [pending: true])

--- a/mix.lock
+++ b/mix.lock
@@ -9,4 +9,5 @@
   "jason_vendored": {:git, "https://github.com/elixir-lsp/jason.git", "ee95ca80cd67b3a499a14f469536140935eb4483", [branch: "vendored"]},
   "mix_task_archive_deps": {:git, "https://github.com/JakeBecker/mix_task_archive_deps.git", "50301a4314e3cc1104f77a8208d5b66ee382970b", []},
   "providers": {:hex, :providers, "1.8.1", "70b4197869514344a8a60e2b2a4ef41ca03def43cfb1712ecf076a0f3c62f083", [:rebar3], [{:getopt, "1.0.1", [hex: :getopt, repo: "hexpm", optional: false]}], "hexpm", "e45745ade9c476a9a469ea0840e418ab19360dc44f01a233304e118a44486ba0"},
+  "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
 }


### PR DESCRIPTION
The previous implementation did not have any bugs (that I saw), but I did find it more difficult to read and understand. I expect performance to be comparable.

For more comprehensive testing I have added StreamData which adds property-based testing. We can probably use that in other portions of the code base as well.